### PR TITLE
fix MCIERR_FILENAME_REQUIRED, the length of filePath cannot exceed 127 on windows

### DIFF
--- a/NetCoreAudio/Players/WindowsPlayer.cs
+++ b/NetCoreAudio/Players/WindowsPlayer.cs
@@ -23,6 +23,7 @@ namespace NetCoreAudio.Players
         {
             FileUtil.ClearTempFiles();
             _fileName = $"\"{FileUtil.CheckFileToPlay(fileName)}\"";
+            Debug.WriteLine($"actual file to play: {_fileName}");
             _playbackTimer = new Timer
             {
                 AutoReset = false

--- a/NetCoreAudio/Utils/FileUtil.cs
+++ b/NetCoreAudio/Utils/FileUtil.cs
@@ -1,22 +1,31 @@
 ﻿using System.IO;
+using System.Text;
 
 namespace NetCoreAudio.Utils
 {
     internal static class FileUtil
     {
         private const string TempDirName = "temp";
-
+        private const int MaxFileNameLength = 255;
+        
         public static string CheckFileToPlay(string originalFileName)
         {
             var fileNameToReturn = originalFileName;
-            if (originalFileName.Contains(" "))
+            if (originalFileName.Contains(" ") || originalFileName.Length > MaxFileNameLength / 2)
             {
-                Directory.CreateDirectory(TempDirName);
-                fileNameToReturn = TempDirName + Path.DirectorySeparatorChar +
-                    Path.GetFileName(originalFileName).Replace(" ", "");
-                File.Copy(originalFileName, fileNameToReturn);
+                var shortPath = new StringBuilder(MaxFileNameLength);
+                if (WindowsUtil.GetShortPathName(originalFileName, shortPath, MaxFileNameLength) > 0)
+                {
+                    fileNameToReturn = shortPath.ToString();
+                }
+                else
+                {
+                    Directory.CreateDirectory(TempDirName);
+                    fileNameToReturn = TempDirName + Path.DirectorySeparatorChar +
+                                       Path.GetFileName(originalFileName).Replace(" ", "");
+                    File.Copy(originalFileName, fileNameToReturn);
+                }
             }
-
             return fileNameToReturn;
         }
 

--- a/NetCoreAudio/Utils/WindowsUtil.cs
+++ b/NetCoreAudio/Utils/WindowsUtil.cs
@@ -8,6 +8,12 @@ namespace NetCoreAudio.Utils
 {
     internal static class WindowsUtil
     {
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        internal static extern int GetShortPathName(
+            [MarshalAs(UnmanagedType.LPTStr)] string path,
+            [MarshalAs(UnmanagedType.LPTStr)] StringBuilder shortPath,
+            int shortPathLength);
+        
         [DllImport("winmm.dll")]
         private static extern int mciSendString(
             string command,


### PR DESCRIPTION
fix MCIERR_FILENAME_REQUIRED, the length of filePath cannot exceed 127