### PR TITLE
Improve Windows path handling for MCI playback

### DIFF
--- a/NetCoreAudio/NetCoreAudio.csproj
+++ b/NetCoreAudio/NetCoreAudio.csproj
@@ -12,7 +12,10 @@
     <RepositoryUrl>https://github.com/mobiletechtracker/NetCoreAudio</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>.NET Core audio</PackageTags>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
+    <PackageVersion>2.0.1</PackageVersion>
+    <AssemblyVersion>2.0.1.0</AssemblyVersion>
+    <FileVersion>2.0.1.0</FileVersion>
     <PackageIconUrl></PackageIconUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>icon.jpg</PackageIcon>

--- a/NetCoreAudio/Players/WindowsPlayer.cs
+++ b/NetCoreAudio/Players/WindowsPlayer.cs
@@ -23,6 +23,9 @@ namespace NetCoreAudio.Players
         {
             FileUtil.ClearTempFiles();
             _fileName = $"\"{FileUtil.CheckFileToPlay(fileName)}\"";
+#if DEBUG
+            Debug.WriteLine($"Actual file passed to MCI: {_fileName}");
+#endif
             _playbackTimer = new Timer
             {
                 AutoReset = false

--- a/NetCoreAudio/Utils/FileUtil.cs
+++ b/NetCoreAudio/Utils/FileUtil.cs
@@ -1,23 +1,46 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace NetCoreAudio.Utils
 {
     internal static class FileUtil
     {
         private const string TempDirName = "temp";
+        private const int MaxPathLengthBeforeFallback = 128;
 
         public static string CheckFileToPlay(string originalFileName)
         {
             var fileNameToReturn = originalFileName;
-            if (originalFileName.Contains(" "))
+            if (originalFileName.Contains(" ") || originalFileName.Length > MaxPathLengthBeforeFallback)
             {
-                Directory.CreateDirectory(TempDirName);
-                fileNameToReturn = TempDirName + Path.DirectorySeparatorChar +
-                    Path.GetFileName(originalFileName).Replace(" ", "");
-                File.Copy(originalFileName, fileNameToReturn);
+                if (!WindowsUtil.TryGetShortPath(originalFileName, out var shortPath))
+                {
+                    Directory.CreateDirectory(TempDirName);
+                    fileNameToReturn = Path.Combine(TempDirName, BuildTempFileName(originalFileName));
+                    File.Copy(originalFileName, fileNameToReturn, true);
+                }
+                else
+                {
+                    fileNameToReturn = shortPath;
+                }
             }
 
             return fileNameToReturn;
+        }
+
+        private static string BuildTempFileName(string originalFileName)
+        {
+            var extension = Path.GetExtension(originalFileName);
+            var baseName = Path.GetFileNameWithoutExtension(originalFileName).Replace(" ", "");
+            if (baseName.Length > 80)
+                baseName = baseName.Substring(0, 80);
+
+            using var sha256 = SHA256.Create();
+            var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(Path.GetFullPath(originalFileName)));
+            var hash = BitConverter.ToString(hashBytes).Replace("-", string.Empty).Substring(0, 10);
+            return $"{baseName}_{hash}{extension}";
         }
 
         public static void ClearTempFiles()

--- a/NetCoreAudio/Utils/WindowsUtil.cs
+++ b/NetCoreAudio/Utils/WindowsUtil.cs
@@ -8,6 +8,12 @@ namespace NetCoreAudio.Utils
 {
     internal static class WindowsUtil
     {
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private static extern uint GetShortPathName(
+            [MarshalAs(UnmanagedType.LPTStr)] string path,
+            [MarshalAs(UnmanagedType.LPTStr)] StringBuilder shortPath,
+            uint shortPathLength);
+
         [DllImport("winmm.dll")]
         private static extern int mciSendString(
             string command,
@@ -72,6 +78,29 @@ namespace NetCoreAudio.Utils
             waveOutSetVolume(IntPtr.Zero, newVolumeAllChannels);
 
             return Task.CompletedTask;
+        }
+
+        internal static bool TryGetShortPath(string path, out string shortPath)
+        {
+            shortPath = string.Empty;
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return false;
+
+            var initialLength = 260u;
+            var buffer = new StringBuilder((int)initialLength);
+            var result = GetShortPathName(path, buffer, initialLength);
+            if (result > initialLength)
+            {
+                buffer = new StringBuilder((int)result);
+                result = GetShortPathName(path, buffer, result);
+            }
+
+            if (result == 0)
+                return false;
+
+            shortPath = buffer.ToString();
+            return !string.IsNullOrWhiteSpace(shortPath);
         }
     }
 


### PR DESCRIPTION
### Motivation
- MCI playback on Windows can fail when file paths contain spaces or are very long, so the code should prefer short (8.3) paths and provide a robust fallback when short paths are unavailable.
- Avoid collisions and repeated-run issues when creating temp files by producing deterministic, sanitized filenames instead of naive copies.

### Description
- Added P/Invoke for `GetShortPathName` and a `TryGetShortPath` helper in `NetCoreAudio/Utils/WindowsUtil.cs` to centralize Windows-specific short-path resolution and to respect OS platform checks.
- Updated `NetCoreAudio/Utils/FileUtil.cs` so `CheckFileToPlay` triggers mitigation for both space-containing and long paths by first attempting `WindowsUtil.TryGetShortPath` and falling back to copying the file into a `temp` folder when short path resolution fails.
- Implemented deterministic temp-filename generation in `FileUtil.BuildTempFileName` using a truncated sanitized basename plus a SHA-256-based hex prefix to avoid collisions and support safe overwrites.
- Added a debug-only log in `NetCoreAudio/Players/WindowsPlayer.cs` to show the actual path passed to MCI when built in debug mode, and added a `MaxPathLengthBeforeFallback` constant to drive fallback behavior.

### Testing
- Attempted to run an automated build with `dotnet build`, but the environment does not have the .NET SDK installed so the build could not be executed and no automated tests were run.
- Local repository checks (`git diff`, `git status`) were used to verify the intended changes were staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f96546edc8328bc144881540f882a)